### PR TITLE
Issue#29

### DIFF
--- a/lib/admin/assets/css/admin.css
+++ b/lib/admin/assets/css/admin.css
@@ -361,3 +361,61 @@ table.widefat.fixed {border-collapse: separate;}
 .wp-submenu.wp-submenu-wrap {
   margin: 0;
 }
+
+/* email cta */
+.vimeography-cta-container .cta-section {
+  margin-left: 50px;
+  padding-left: 20px;
+  border-left: 10px solid;
+  margin-top:25px;
+  margin-bottom:25px;
+  max-width:300px;
+}
+
+.vimeography-cta-container .cta-section.primary{
+  border-color:#6CB5E8;
+}
+
+.vimeography-cta-container .cta-section.secondary{
+  border-color:#FFBA08;
+}
+
+.vimeography-cta-container .cta-section.tertiary{
+  border-color:#E94F37;
+}
+
+.vimeography-cta-container input,.vimeography-cta-container select {
+  padding: 12px 8px;
+  width: 100%;
+}
+
+.vimeography-cta-container input[type="submit"]{
+  background:#44BBA4;
+  border:1px solid #666666;
+  border-radius:3px;
+  color:white;
+  font-size:16px;
+  font-weight:bold;
+}
+
+.vimeography-cta-container input[type="submit"]:hover{
+  background:#81d6c6;
+  transition:all 0.1s ease-in-out;
+}
+
+#signup-form .success,
+#signup-form .failure {
+  display: block;
+  max-width: 300px;
+  padding: 10px;
+  margin-left: 50px;
+}
+
+#signup-form .success{
+  border-left: 10px solid #FFBA08;
+}
+
+#signup-form .failure{
+  border-left: 10px solid #E94F37;
+}
+

--- a/lib/admin/base.php
+++ b/lib/admin/base.php
@@ -71,6 +71,21 @@ class Vimeography_Base {
     return get_option('vimeography_has_user_signed_up');
   }
   
+  /**
+   * Specifies width of gallery, based on if the user has signed up
+   * 
+   * @return string
+   */
+  public static function gallery_width() {
+    if(get_option('vimeography_has_user_signed_up')){
+      $result = '70%';
+    }
+    else{
+      $result = '50%';
+    }
+    return $result;
+  }
+  
 
   /**
    * Gets the default settings created when Vimeography is installed.

--- a/lib/admin/base.php
+++ b/lib/admin/base.php
@@ -60,6 +60,17 @@ class Vimeography_Base {
   public static function has_pro() {
     return is_plugin_active('vimeography-pro/vimeography-pro.php');
   }
+  
+  
+  /**
+   * Checks if the user has already signed up for the email list
+   * 
+   * @return boolean
+   */
+  public static function has_user_signed_up() {
+    return get_option('vimeography_has_user_signed_up');
+  }
+  
 
   /**
    * Gets the default settings created when Vimeography is installed.

--- a/lib/admin/templates/gallery/edit/layout.mustache
+++ b/lib/admin/templates/gallery/edit/layout.mustache
@@ -128,9 +128,11 @@
       <div id="vimeography-gallery-container" style="width: {{gallery_width}}; margin-left: 305px; float:left;">
         {{{vimeography}}}
       </div>
+      {{^has_user_signed_up}}
       <div class="vimeography-cta-container" style="width: calc(50% - 325px); margin-left: 20px; float:left;">
         {{> email_cta}}
       </div>
+      {{/has_user_signed_up}}
   </div>
   {{/gallery}}
 </div>

--- a/lib/admin/templates/gallery/edit/layout.mustache
+++ b/lib/admin/templates/gallery/edit/layout.mustache
@@ -61,7 +61,7 @@
           event.preventDefault();
           var form = $(this);
           $.ajax({
-            method: form.attr('type'),
+            method: form.attr('method'),
             url: form.attr('action'),
             data: form.serialize(),
             dataType: 'json',

--- a/lib/admin/templates/gallery/edit/layout.mustache
+++ b/lib/admin/templates/gallery/edit/layout.mustache
@@ -125,7 +125,7 @@
       </div> <!-- end slider -->
 
     </div> <!-- End vimeography-gallery-menu-container -->
-      <div id="vimeography-gallery-container" style="width: 50%; margin-left: 305px; float:left;">
+      <div id="vimeography-gallery-container" style="width: {{gallery_width}}; margin-left: 305px; float:left;">
         {{{vimeography}}}
       </div>
       <div class="vimeography-cta-container" style="width: calc(50% - 325px); margin-left: 20px; float:left;">

--- a/lib/admin/templates/gallery/edit/layout.mustache
+++ b/lib/admin/templates/gallery/edit/layout.mustache
@@ -102,10 +102,12 @@
       </div> <!-- end slider -->
 
     </div> <!-- End vimeography-gallery-menu-container -->
-
-    <div id="vimeography-gallery-container" style="max-width: 60%; margin-left: 305px;">
-      {{{vimeography}}}
-    </div>
+      <div id="vimeography-gallery-container" style="width: 50%; margin-left: 305px; float:left;">
+        {{{vimeography}}}
+      </div>
+      <div class="vimeography-cta-container" style="width: calc(50% - 325px); margin-left: 20px; float:left;">
+        {{> email_cta}}
+      </div>
   </div>
   {{/gallery}}
 </div>

--- a/lib/admin/templates/gallery/edit/layout.mustache
+++ b/lib/admin/templates/gallery/edit/layout.mustache
@@ -75,7 +75,7 @@
             });
           }).fail(function(data){
             $('.failure').remove();
-            $('#signup-form').append("<span class='failure'>Hmm...something's not right. Usually this happens because you have already claimed a discount. Check your email for your discount, of contact us directly if you need more help.</span>");
+            $('#signup-form').append("<span class='failure'>Hmm...something's not right. Usually this happens because you have already claimed a discount. Check your email for your discount, or contact us directly if you need more help.</span>");
           })
           return this;
         })

--- a/lib/admin/templates/gallery/edit/layout.mustache
+++ b/lib/admin/templates/gallery/edit/layout.mustache
@@ -55,7 +55,24 @@
         }).mouseout(function(){
           $(this).find('.icon-ok').stop(true, true).fadeOut(200);
         });
-
+        
+        // Signup form actions
+        $('#signup-form form').submit(function(event){
+          event.preventDefault();
+          var form = $(this);
+          $.ajax({
+            method: form.attr('type'),
+            url: form.attr('action'),
+            data: form.serialize(),
+            dataType: 'json',
+          }).done(function(data){
+            $('#signup-form').empty().append("<span class='success'>Alright champ, you're signed up. check your inbox for your code.</span>");
+          }).fail(function(data){
+            $('.failure').remove();
+            $('#signup-form').append("<span class='failure'>Hmm...something's not right. Usually this happens because you have already claimed a discount. Check your email for your discount, of contact us directly if you need more help.</span>");
+          })
+          return this;
+        })
       });
     }(jQuery))
   </script>

--- a/lib/admin/templates/gallery/edit/layout.mustache
+++ b/lib/admin/templates/gallery/edit/layout.mustache
@@ -67,6 +67,12 @@
             dataType: 'json',
           }).done(function(data){
             $('#signup-form').empty().append("<span class='success'>Alright champ, you're signed up. check your inbox for your code.</span>");
+            var data = {
+              'action': 'vimeography_toggle_signup_form',
+            };
+            jQuery.post(ajaxurl, data, function(response){
+              console.log(response);
+            });
           }).fail(function(data){
             $('.failure').remove();
             $('#signup-form').append("<span class='failure'>Hmm...something's not right. Usually this happens because you have already claimed a discount. Check your email for your discount, of contact us directly if you need more help.</span>");

--- a/lib/admin/templates/gallery/edit/partials/email_cta.mustache
+++ b/lib/admin/templates/gallery/edit/partials/email_cta.mustache
@@ -3,7 +3,7 @@
           <p>Join our newsletter and get a discount code good for 10% off of your next purchase sent directly to your inbox!</p>
         </div>
         <div id="signup-form">
-          <form action="https://vimeography.com/offers/email" type="post">
+          <form action="https://vimeography.com/offers/email" method="post">
             <div class="cta-section secondary">
               <label for="name">Name</label><input required type="text" name="name" id="">
               <label for="email">Email</label><input required type="text" name="email" id="">

--- a/lib/admin/templates/gallery/edit/partials/email_cta.mustache
+++ b/lib/admin/templates/gallery/edit/partials/email_cta.mustache
@@ -1,0 +1,45 @@
+        <div class="cta-section primary">
+          <h2>Join our Newsletter</h2>
+          <p>Join our newsletter and get a discount code good for 10% off of your next purchase sent directly to your inbox!</p>
+        </div>
+        <div id="signup-form">
+          <form action="https://vimeography.com/offers/email" type="post">
+            <div class="cta-section secondary">
+              <label for="name">Name</label><input required type="text" name="name" id="">
+              <label for="email">Email</label><input required type="text" name="email" id="">
+              <label for="industry">Industry</label>
+                <select required name="industry" id="">
+                  <option value='arts'>Arts and Artists</option>
+                  <option value='consulting'>Consulting</option>
+                  <option value='agency'>Creative Services/Agency</option>
+                  <option value='ecommerce'>Ecommerce</option>
+                  <option value='education'>Education and Training</option>
+                  <option value='entertainment'>Entertainment and Events</option>
+                  <option value='finance'>Finance</option>
+                  <option value='freelance'>Freelancer</option>
+                  <option value='gaming'>Gaming</option>
+                  <option value='government'>Government</option>
+                  <option value='health'>Health and Fitness</option>
+                  <option value='hobbies'>Hobbies</option>
+                  <option value='marketing'>Marketing and Advertising</option>
+                  <option value='media'>Media and Publishing</option>
+                  <option value='music'>Music and Musicians</option>
+                  <option value='nonprofit'>Non-Profit</option>
+                  <option value='online_communities'>Online Communities</option>
+                  <option value='other'>Other</option>
+                  <option value='photo_video'>Photo and Video</option>
+                  <option value='real_estate'>Real Estate</option>
+                  <option value='religion'>Religion</option>
+                  <option value='retail'>Retail</option>
+                  <option value='small_business'>Small Business</option>
+                  <option value='software'>Software and Web App</option>
+                  <option value='sports'>Sports</option>
+                  <option value='student'>Student</option>
+                  <option value='travel'>Travel and Transportation</option>
+                </select>
+            </div>
+            <div class="cta-section tertiary">
+              <input type="submit" value="Claim Your Discount">
+            </div>
+          </form>
+        </div>

--- a/lib/ajax.php
+++ b/lib/ajax.php
@@ -3,6 +3,7 @@
 class Vimeography_Ajax extends Vimeography {
   public function __construct() {
     add_action( 'wp_ajax_vimeography_ajax_get_cached_videos', array( &$this, 'vimeography_ajax_get_cached_videos' ) );
+    add_action( 'wp_ajax_vimeography_toggle_signup_form', array( &$this, 'vimeography_toggle_signup_form' ) );
   }
 
   public function vimeography_ajax_get_cached_videos() {
@@ -23,5 +24,11 @@ class Vimeography_Ajax extends Vimeography {
     echo json_encode($videos);
 
     die;
+  }
+  
+  //Flags the user if they have signed up to the email list
+  public function vimeography_toggle_signup_form() {
+    update_option('vimeography_has_user_signed_up',true);
+    wp_die();
   }
 }


### PR DESCRIPTION
Added a call to action to the sidebar of the edit gallery section of Vimeography.
![image](https://cloud.githubusercontent.com/assets/8210827/19187382/24bd86ba-8c59-11e6-84a2-a9c53ce95108.png)


Here is what pops up on-error (note that the fields do not clear, I just removed them for privacy reasons)
![image](https://cloud.githubusercontent.com/assets/8210827/19187347/f1b1a120-8c58-11e6-8c54-56c53155171b.png)

Here is what happens when the form is sucessfully submitted:
![image](https://cloud.githubusercontent.com/assets/8210827/19187368/15646206-8c59-11e6-92a6-c876d5acd722.png)
