### PR TITLE
Change referrer meta to origin-when-crossorigin

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -29,7 +29,7 @@ class Vimeography_Init extends Vimeography
     $enable = apply_filters('vimeography.privacy.enable_referrer', false);
 
     if ($enable) {
-      echo '<meta name="referrer" content="origin">';
+      echo '<meta name="referrer" content="origin-when-crossorigin">';
     }
 
     return;


### PR DESCRIPTION
Fixes compatibility issue with woocommerce that sometimes relies on referrer page